### PR TITLE
tag each docker image with the date and time

### DIFF
--- a/.github/workflows/docker-image-ghcr.yml
+++ b/.github/workflows/docker-image-ghcr.yml
@@ -29,9 +29,11 @@ jobs:
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        uses: docker/metadata-action@v4
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value={{date 'YYYYMMDD-HHmmss' tz='Europe/Stockholm'}}
 
       - name: Build and push Docker image
         uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc


### PR DESCRIPTION
Modification of the github action to tag each new docker image with the date and time of build.